### PR TITLE
Use minimal set of annotations for COGEQC orthogroup QC

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -204,13 +204,14 @@ workflow PHYLORTHOLOGY {
     //
     COGEQC(
         ORTHOFINDER_MCL_TEST.out.inflation_dir,
+        params.min_num_spp_per_og,
         ch_annotations
     )
     ch_cogeqc_summary = COGEQC.out.cogeqc_summary.collect()
     ch_versions = ch_versions.mix(COGEQC.out.versions)
 
     // Now, from these orthogroup summaries, select the best inflation parameter
-    SELECT_INFLATION(ch_cogeqc_summary)
+    SELECT_INFLATION(ch_cogeqc_summary, params.min_num_spp_per_og)
         .best_inflation.text.trim()
         .set { ch_best_inflation }
     ch_versions = ch_versions.mix(SELECT_INFLATION.out.versions)

--- a/modules/local/cogeqc.nf
+++ b/modules/local/cogeqc.nf
@@ -13,7 +13,8 @@ process COGEQC {
 
     input:
     path orthofinder_outdir
-    path prot_annotations // Base filepath to where protein annotations are stored
+    val min_spp             // Minimum number of species for orthogroup retention
+    path prot_annotations   // Base filepath to where protein annotations are stored
 
     output:
     path "*_cogeqc_summary.tsv" , emit: cogeqc_summary
@@ -27,10 +28,9 @@ process COGEQC {
     """
     # Assess orthogroups inferred using each inflation parameter, summarizing
     # how well they group proteins with the same domains together, as well as
-    # other summary stats like number of ogs with >= 4 species, per-species
-    # gene count per-og, etc.
-    cogeqc_summarize_ogs.R ${orthofinder_outdir}
-
+    # other summary stats like number of ogs with >= the minimum # species, 
+    # per-species gene count per-og, etc.
+    cogeqc_summarize_ogs.R ${orthofinder_outdir} ${min_spp}
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         cogeqc: \$( cat version.txt | head -n1 | sed "s/\\[1] ‘//g" | sed "s/’//g" )

--- a/modules/local/select_inflation.nf
+++ b/modules/local/select_inflation.nf
@@ -13,12 +13,13 @@ process SELECT_INFLATION {
 
     input:
     path og_summaries // Files with summaries of orthogroups inferred using a specific inflation parameter
+    val min_spp       // Minimum number of species for orthogroup phylogenetic inference.
 
     output:
     path "cogeqc_results.tsv"       , emit: cogeqc_summary
     path "best_inflation_param.txt" , emit: best_inflation
-    path "inflation_summaries.pdf"  ,  emit: summary_plot
-    path "versions.yml"             ,            emit: versions
+    path "inflation_summaries.pdf"  , emit: summary_plot
+    path "versions.yml"             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -34,12 +35,10 @@ process SELECT_INFLATION {
     rm *_cogeqc_summary.tsv
     
     # Run the script to summarize and produce a figure of these results.
-    select_inflation.R
-
+    select_inflation.R ${min_spp}
     # And spit out the value of the selected inflation parameter to be
     # captured into a channel from stdout
     sed -i "s/\\[1] //g" best_inflation_param.txt
-
     cat <<- END_VERSIONS > versions.yml
     "${task.process}":
         tidyverse: \$( grep "tidyverse" version.txt | sed "s/\\[1] ‘//g" | sed "s/’//g" )


### PR DESCRIPTION
A handful of little changes to the annotation download and COGEQC modules:

1) If the user doesn't want to download any annotations they now specify the parameter as "minimal" (previously was "none" which was a bit confusing/misleading).
2) Actually only download the two annotations we use to calculate the quality score for (previously downloaded and summarized/plotted for several other annotations that were not actually used)
3) A couple little fixed to the cogeqc and select_inflation R-script to make sure the summaries and plots that were written to file included only what we want to report, and no modification of table contents needed to be done post-hoc during inflation parameter selection. 