### PR TITLE
speciesrax/generax fix for excluded gene families

### DIFF
--- a/modules/local/generax.nf
+++ b/modules/local/generax.nf
@@ -38,6 +38,9 @@ process GENERAX {
     # to be excluded from analyses. 
     sed -E -i '/>/!s/U/-/g' *.fa 
     
+    # Do the same for Pyrrolysine
+    sed -E -i '/>/!s/O/-/g' *.fa 
+
     mpiexec \\
         -np ${task.cpus} \\
         --allow-run-as-root \\

--- a/modules/local/speciesrax.nf
+++ b/modules/local/speciesrax.nf
@@ -38,6 +38,9 @@ process SPECIESRAX {
     # to be excluded from analyses. 
     sed -E -i '/>/!s/U/-/g' *.fa 
     
+    # Do the same for Pyrrolysine
+    sed -E -i '/>/!s/O/-/g' *.fa 
+
     mpiexec \\
         -np ${task.cpus} \\
         --allow-run-as-root \\


### PR DESCRIPTION
SpeciesRax and GeneRax both use RAxML under the hood to optimize tree topologies. Whereas IQ-TREE and MAFFt can handle some rare amino acids (I know at least selenocysteine - U, but possible also pyrrolysine - O), RAxML can't. So, if these are present in MSAs, these gene families are excluded from generax/speciesrax analysis. 

This change just goes in and removes these from staged files in the generax and speciesrax modules. Seems to fix the issue.  