### PR TITLE
leave spp headers unchanged when reading in og counts

### DIFF
--- a/bin/og_tax_summary.R
+++ b/bin/og_tax_summary.R
@@ -13,7 +13,7 @@ num_grp_filt <- as.numeric(args[4])
 copy_num_filt1 <- as.numeric(args[5])
 copy_num_filt2 <- as.numeric(args[6])
 
-ogs <- read.delim(ogcounts)
+ogs <- read.delim(ogcounts, check.names = FALSE)
 samples <- read.delim(samples, sep = ",")
 
 colnames(ogs) <- gsub("\\..*", "", colnames(ogs))


### PR DESCRIPTION
R is annoying. One species had a hyphen in the name. So, when I read in a file that included the species name in the column, R replaced it with a `.`.

Fun. `check.names = FALSE` fixes this. 