### PR TITLE
improved, descriptive publishdir names

### DIFF
--- a/modules/local/clipkit.nf
+++ b/modules/local/clipkit.nf
@@ -6,7 +6,7 @@ process CLIPKIT {
         '' }"
 
     publishDir(
-        path: "${params.outdir}/trimmed_msas",
+        path: "${params.outdir}/clipkit_cleaned_msas",
         mode: params.publish_dir_mode,
         saveAs: { fn -> fn.substring(fn.lastIndexOf('/')+1) },
     )

--- a/modules/local/veryfasttree.nf
+++ b/modules/local/veryfasttree.nf
@@ -7,6 +7,12 @@ process VERYFASTTREE {
     container "${ workflow.containerEngine == 'docker' ? 'austinhpatton123/veryfasttree_3.2.1:0.0.1':
         '' }"
 
+    publishDir(
+        path: "${params.outdir}/veryfasttree_gene_trees",
+        mode: params.publish_dir_mode,
+        saveAs: { fn -> fn.substring(fn.lastIndexOf('/')+1) },
+    )
+
     input:
     path(alignment)
     val model // not used

--- a/modules/nf-core-modified/iqtree.nf
+++ b/modules/nf-core-modified/iqtree.nf
@@ -10,6 +10,12 @@ process IQTREE {
     container "${ workflow.containerEngine == 'docker' ? 'arcadiascience/iqtree_2.2.0.5:0.0.1':
         '' }"
 
+    publishDir(
+        path: "${params.outdir}/iqtree_gene_trees",
+        mode: params.publish_dir_mode,
+        saveAs: { fn -> fn.substring(fn.lastIndexOf('/')+1) },
+    )
+    
     input:
     path(alignment)
     val model

--- a/modules/nf-core-modified/iqtree_pmsf.nf
+++ b/modules/nf-core-modified/iqtree_pmsf.nf
@@ -10,6 +10,12 @@ process IQTREE_PMSF {
 
     container "${ workflow.containerEngine == 'docker' ? 'arcadiascience/iqtree_2.2.0.5:0.0.1':
         '' }"
+    
+    publishDir(
+        path: "${params.outdir}/iqtree_pmsf_gene_trees",
+        mode: params.publish_dir_mode,
+        saveAs: { fn -> fn.substring(fn.lastIndexOf('/')+1) },
+    )
 
     input:
     path(alignment)

--- a/modules/nf-core-modified/mafft.nf
+++ b/modules/nf-core-modified/mafft.nf
@@ -11,6 +11,12 @@ process MAFFT {
         'https://depot.galaxyproject.org/singularity/mafft:7.490--h779adbc_0':
         'quay.io/biocontainers/mafft:7.490--h779adbc_0' }"
 
+    publishDir(
+        path: "${params.outdir}/mafft_alignments",
+        mode: params.publish_dir_mode,
+        saveAs: { fn -> fn.substring(fn.lastIndexOf('/')+1) },
+    )
+    
     input:
     path(fasta)
     val num_spp_tree_msas // Purely utilitarian: used to prioritize gene families used in species tree inference.


### PR DESCRIPTION
This PR just includes a number of changes so that the publishdirs are actually named in an informative way, and are consistent in naming convention across alternative methods for alignment, trimming, and tree inference. 