### PR TITLE
Remove extraneous, broken UniProt annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ## Quick Start
 
+**NOTE: Unfortunately, at this time NovelTree is not compatible with Apple silicon/ARM architectures (e.g. M1, M2 chips).**
+
 **1.** Install [`Nextflow`](https://www.nextflow.io/docs/latest/getstarted.html#installation) (`>=21.10.3`).
 
 **2.** Install [`Docker`](https://docs.docker.com/engine/installation/).
@@ -20,6 +22,14 @@
 ```bash
 nextflow run . -profile docker -params-file https://github.com/Arcadia-Science/test-datasets/raw/main/noveltree/tsar_downsamp_test_parameters.json
 ```
+
+In cases where you need to specify resource usage limits to NovelTree (e.g. you are running it on a local desktop or laptop), you can specify the maximum available CPU and memory resources as follows:
+
+```bash
+nextflow run . -profile docker -params-file https://github.com/Arcadia-Science/test-datasets/raw/main/noveltree/tsar_downsamp_test_parameters.json  --max_cpus 12 --max_memory 16GB
+```
+
+Nextflow requires some memory resources to be allocated for overhead - consequently, we suggest reducing the specified `--max_memory` by ~2GB or more below the amount available to your particular compute environment.
 
 **NOTE: Currently the workflow only works using the docker profile.**
 
@@ -37,7 +47,7 @@ To account for the confounding effects of sequence length (and thus evolutionary
 **1.** An initial round for inflation parameter testing on a (reduced) set of proteomes for which UniProt protein accessions are available, and
 **2.** A second round on the complete dataset.
 
-Once the first round of MCL clustering has completed, `NovelTree` summarizes orthogroups based on a number of metrics, choosing a best-performing inflation parameter for the analysis of the full dataset. This includes a functional protein annotation score calculated with [`COGEQC`](https://almeidasilvaf.github.io/cogeqc/index.html), which quantifies the ratio of InterPro domain "Homogeneity" of domains within orthogroups to "Dispersal" of domains among orthogroups. This statistic is also calculated for OMA orthology database IDs.
+Once the first round of MCL clustering has completed, `NovelTree` summarizes orthogroups based on a number of metrics, choosing a best-performing inflation parameter for the analysis of the full dataset. This includes a functional protein annotation score calculated with [`COGEQC`](https://almeidasilvaf.github.io/cogeqc/index.html), which quantifies the ratio of InterPro domain "Homogeneity" within orthogroups to "Dispersal" of domains among orthogroups. This statistic is also calculated for OMA orthology database IDs.
 
 With orthogroups/gene families inferred, `NovelTree` will summarize each gene family on the basis of their taxonomic and copy number distribution, quantifying the number of species/clades included in each, as well as the mean per-species copy number. These summaries facilitate 'filtering' for sufficiently conserved/computationally tractable gene families for downstream phylogenetic analysis. In other words, it may be best, depending on use-case, to avoid excessively small (e.g. < 4 species) or large gene families (e.g. > 50 species and mean copy # of 20 - this upper limit will depend on available computational resources) for the purpose of this workflow. We filter to produce two subsets: a conservative set for species tree inference (e.g. >= 4 species, mean copy \# <= 5), and one for which only gene family trees will be inferred (e.g. >= 4 species, mean copy \# <= 10).
 
@@ -55,7 +65,7 @@ With the rooted species tree inferred, `NovelTree` uses [`OrthoFinder`](https://
 For a detailed description of basic- to advance-usage of the workflow, please see the [`usage.md`](docs/usage.md) file.
 
 ## Outputs
-For a detailed description of basic- to advance-usage of the workflow, please see the [`outputs.md`](docs/outputs.md) file.
+For a detailed description of workflow outputs, please see the [`outputs.md`](docs/outputs.md) file.
 
 ---
 

--- a/bin/protein_annotation.py
+++ b/bin/protein_annotation.py
@@ -9,62 +9,16 @@ import pandas as pd
 import os
 
 # Columns (query fields) that we will use when accessing UniProt protein annotations
-COLUMNS = ['organism_name', 'organism_id',  'accession', 'gene_names', 
-    'gene_primary', 'gene_synonym', 'protein_name', 'length', 'mass', 
-    'cc_mass_spectrometry', 'virus_hosts', 'organelle', 'cc_rna_editing',
-    'go_p', 'go_c', 'go_f', 'go_id','absorption', 'ft_act_site', 'cc_activity_regulation',
-    'ft_binding', 'cc_catalytic_activity', 'cc_cofactor','ft_dna_bind', 'ec', 
-    'cc_function', 'kinetics', 'cc_pathway','ph_dependence', 'redox_potential', 
-    'rhea', 'ft_site','temp_dependence','cc_interaction', 'cc_subunit',
-    'xref_biogrid', 'xref_corum', 'xref_complexportal', 'xref_dip','xref_elm', 
-    'xref_intact', 'xref_mint', 'xref_string','cc_allergen','cc_biotechnology', 
-    'cc_disruption_phenotype','cc_disease','ft_mutagen', 'cc_pharmaceutical',
-    'cc_toxic_dose','ft_intramem', 'cc_subcellular_location', 'ft_topo_dom', 
-    'ft_transmem','ft_chain', 'ft_crosslnk', 'ft_disulfid', 'ft_carbohyd',
-    'ft_init_met', 'ft_lipid', 'ft_mod_res', 'ft_peptide','cc_ptm', 'ft_propep', 
-    'ft_signal', 'ft_transit','xref_carbonyldb', 'xref_depod', 'xref_glyconnect', 
-    'xref_glygen','xref_metosite', 'xref_phosphositeplus', 'xref_swisspalm', 
-    'xref_unicarbkb','xref_iptmnet','ft_coiled', 'ft_compbias', 'cc_domain', 
-    'ft_domain','ft_motif', 'protein_families', 'ft_region', 'ft_repeat',
-    'ft_zn_fing','xref_cdd', 'xref_disprot', 'xref_gene3d', 'xref_hamap',
-    'xref_ideal', 'xref_interpro', 'xref_panther', 'xref_pirsf','xref_prints', 
-    'xref_prosite', 'xref_pfam', 'xref_prodom','xref_sfld', 'xref_smart', 
-    'xref_supfam', 'xref_ccds', 'xref_embl', 'xref_pir', 
-    'xref_refseq','xref_alphafolddb', 'xref_bmrb', 'xref_pcddb', 'xref_pdb',
-    'xref_pdbsum', 'xref_sasbdb', 'xref_smr', 'xref_brenda', 'xref_biocyc', 
-    'xref_pathwaycommons', 'xref_plantreactome','xref_reactome', 'xref_sabio-rk', 
-    'xref_signor', 'xref_signalink','xref_unipathway','xref_genetree', 'xref_hogenom', 
-    'xref_inparanoid', 'xref_ko','xref_oma', 'xref_orthodb', 'xref_phylomedb', 
-    'xref_treefam','xref_eggnog']
+COLUMNS = ['organism_name', 'organism_id', 'accession', 'xref_interpro', 'xref_oma']
 
     # Now define the different annotation sets - we will pull out tables for each.
 ANNOTATION_SETS = {
-    'cogeqc': ['organism_name', 'organism_id', 'accession', 'xref_interpro', 'xref_oma'],
-    'seq_meta': ['organism_name', 'organism_id',  'accession', 'gene_names', 'gene_primary', 'gene_synonym', 'protein_name', 'length', 'mass', 'cc_mass_spectrometry', 'virus_hosts', 'organelle', 'cc_rna_editing'],
-    'seq_gos': ['organism_name', 'organism_id', 'accession', 'go_p', 'go_c', 'go_f', 'go_id'],
-    'seq_funcs': ['organism_name', 'organism_id', 'accession', 'absorption', 'ft_act_site', 'cc_activity_regulation','ft_binding', 'cc_catalytic_activity', 'cc_cofactor','ft_dna_bind', 'ec', 'cc_function', 'kinetics', 'cc_pathway','ph_dependence', 'redox_potential', 'rhea', 'ft_site','temp_dependence'],
-    'seq_inter': ['organism_name', 'organism_id', 'accession', 'cc_interaction', 'cc_subunit'],
-    'seq_interdbs': ['organism_name', 'organism_id', 'accession', 'xref_biogrid', 'xref_corum', 'xref_complexportal', 'xref_dip','xref_elm', 'xref_intact', 'xref_mint', 'xref_string'],
-    'seq_biotech': ['organism_name', 'organism_id', 'accession', 'cc_allergen','cc_biotechnology', 'cc_disruption_phenotype','cc_disease','ft_mutagen', 'cc_pharmaceutical','cc_toxic_dose'],
-    'seq_localize': ['organism_name', 'organism_id', 'accession', 'ft_intramem', 'cc_subcellular_location', 'ft_topo_dom', 'ft_transmem'],
-    'seq_ptm': ['organism_name', 'organism_id', 'accession', 'ft_chain', 'ft_crosslnk', 'ft_disulfid', 'ft_carbohyd','ft_init_met', 'ft_lipid', 'ft_mod_res', 'ft_peptide','cc_ptm', 'ft_propep', 'ft_signal', 'ft_transit'],
-    'seq_xptmdb': ['organism_name', 'organism_id', 'accession', 'xref_carbonyldb', 'xref_depod', 'xref_glyconnect', 'xref_glygen','xref_metosite', 'xref_phosphositeplus', 'xref_swisspalm', 'xref_unicarbkb','xref_iptmnet'],
-    'seq_domains': ['organism_name', 'organism_id', 'accession', 'ft_coiled', 'ft_compbias', 'cc_domain', 'ft_domain','ft_motif', 'protein_families', 'ft_region', 'ft_repeat','ft_zn_fing'],
-    'seq_xfamdom': ['organism_name', 'organism_id', 'accession', 'xref_cdd', 'xref_disprot', 'xref_gene3d', 'xref_hamap','xref_ideal', 'xref_interpro', 'xref_panther', 'xref_pirsf','xref_prints', 'xref_prosite', 'xref_pfam', 'xref_prodom','xref_sfld', 'xref_smart', 'xref_supfam'],
-    'seq_xseqdbs': ['organism_name', 'organism_id', 'accession', 'xref_ccds', 'xref_embl', 'xref_pir', 'xref_refseq'],
-    'seq_x3ddbs': ['organism_name', 'organism_id', 'accession', 'xref_alphafolddb', 'xref_bmrb', 'xref_pcddb', 'xref_pdb','xref_pdbsum', 'xref_sasbdb', 'xref_smr'],
-    'seq_xenzpath': ['organism_name', 'organism_id', 'accession', 'organism_name', 'organism_id', 'accession', 'xref_brenda', 'xref_biocyc', 'xref_pathwaycommons', 'xref_plantreactome','xref_reactome', 'xref_sabio-rk', 'xref_signor', 'xref_signalink','xref_unipathway'],
-    'seq_xortho': ['organism_name', 'organism_id', 'accession', 'xref_genetree', 'xref_hogenom', 'xref_inparanoid', 'xref_ko','xref_oma', 'xref_orthodb', 'xref_phylomedb', 'xref_treefam','xref_eggnog']
+    'cogeqc': ['organism_name', 'organism_id', 'accession', 'xref_interpro', 'xref_oma']
 }
 
 # Suffixes for each annotation filename
-ANNOT_NAMES = ['_cogeqc_annotations.tsv', '_prot_metadat.tsv', '_prot_gene_ontologies.tsv', 
-    '_prot_functions.tsv', '_prot_interactions.tsv', '_prot_interactions_xref.tsv',
-    '_prot_biotech_annots.tsv', '_prot_localization.tsv', '_prot_post_trans_mods.tsv', 
-    '_prot_post_trans_mods_xref.tsv', '_prot_fams_domains.tsv', '_prot_fams_domains_xref.tsv',
-    '_prot_seq_dbs_xref.tsv', '_prot_3d_dbs_xref.tsv', '_prot_enzyme_paths_xref.tsv', 
-    '_prot_orthology_dbs.tsv']
-        
+ANNOT_NAMES = ['_cogeqc_annotations.tsv']
+
 def fetch_batch(batch_accessions, organism_name, columns):
     uniprot = UniProt()
     query = " OR ".join([f"accession:{acc}" for acc in batch_accessions])

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -7,9 +7,7 @@ Note that a detailed walkthrough of how the results of NovelTree may be summariz
 - Batch summary results for each species, to each lineage dataset.  
 - Directory for each species' busco analysis with more detailed output.  
 
-**2.** `protein_annotations/`: protein annotations obtained per each species for which uniprot accessions (i.e. those corresponding to RefSeq protein accessions) are available.  
-
-- Which annotations are included here depends on how the "download_annots" parameter was specified.  
+**2.** `protein_annotations/`: protein annotations (InterPro domain and OMA orthology group ID) obtained per each species for which uniprot accessions (i.e. those corresponding to RefSeq protein accessions) are available.  
 
 **3.** `diamond/`: contains the results of all pairwise comparisons of sequence similarity, between and within species using diamond BLASTP.  
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -164,33 +164,7 @@ process {
 
 #### 2. [`ANNOTATE_UNIPROT`](modules/local/annotate_uniprot.nf):
 
-- `download_annots`: Specified in the parameter file.
-- **Parameter may be specified as one of three things:**
-  i. `all` - download all 16 possible sets of protein annotations from UniProt where possible.
-  ii. `minimal` - download only the minimum necessary annotations that are used by cogeqc for gene family inference quality assessments.
-  iii. A quoted, comma separated string of select numbers 1-16: example `"1,2,4,7,10"`. Numbers correspond to the index of annotations the user would like to download. See below for the correspondance and brief description of each annotation. For indices 4-16 (in particular) see https://www.uniprot.org/help/return_fields.
-  ```
-  1. Minimal set of protein annotations/metadata required for COGEQC gene family inference:
-     protein external IDs for InterPro, OMA
-  2. General protein metadata: protein name, length, mass, information from mass spec
-     experiments, host organisms (for viral proteins), which organelle (if relevant)
-     encoding the protein, any AA variants due to RNA editing
-  3. Gene ontologies - biological process, cellular component, molecular function,
-     ontology ID
-  4. Function: Multiple annotations pertaining to the molecular function of the protein
-  5. Interactions
-  6. Protein-protein interactions (external database reference IDs)
-  7. Pathology & biotech
-  8. Subcellular location
-  9. Post-translation modification (PTM) / processsing
-  10. PTM databases
-  11. Protein family & domains
-  12. Protein family/group databases
-  13. Sequence databases
-  14. 3D structure databases
-  15. Enzyme and pathway databases
-  16. Phylogenomic databases
-  ```
+- Downloads minimal set of protein annotations/metadata required for COGEQC gene family inference: protein external IDs for InterPro domain, OMA orthology group.
 
 #### 3. [`DIAMOND_BLASTP`](modules/nf-core-modified/diamond_blastp.nf):
 


### PR DESCRIPTION
This PR simplifies the annotation module substantially. We now only obtain the UniProt return fields for the annotations used by `COGEQC` for MCL selection (InterPro domain and OMA orthology group ID). The `README`, `usage.md` and `outputs.md` documentation files are updated correspondingly. 

Additionally, in the `README` we now:
1. Highlight that due to changes in NovelTree's dependencies, `NovelTree` no longer is unfortunately no longer compatible with Apple silicon.
2. Provide simple examples of how to specify available resources (e.g. number CPUs, memory) when running `NovelTree`. Without doing so, users may run into errors thrown by Nextflow due to incompatible process specifications for certain modules. 