### PR TITLE
AWS cost tracking for Arcadia config

### DIFF
--- a/conf/arcadia.config
+++ b/conf/arcadia.config
@@ -19,6 +19,23 @@ params {
     awsregion       = 'us-west-1'
     docker_registry = '943220452459.dkr.ecr.us-west-1.amazonaws.com'
 
+    // AWS cost allocation labels for Arcadia Batch runs.
+    // Override these at launch with --cost_dataset, --cost_owner, or --cost_run_id.
+    cost_project = 'noveltree'
+    cost_dataset = 'unset'
+    cost_owner   = System.getenv('USER') ?: 'unknown'
+    cost_run_id  = System.getenv('NOVELTREE_RUN_ID') ?: new java.text.SimpleDateFormat('yyyyMMdd-HHmmss').format(new Date())
+
     // Pipeline mode
     preprocess = true
+}
+
+process {
+    resourceLabels = [
+        Project : params.cost_project,
+        Dataset : params.cost_dataset,
+        Owner   : params.cost_owner,
+        RunId   : params.cost_run_id,
+        Pipeline: 'noveltree'
+    ]
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -221,6 +221,29 @@
                     "description": "The AWS region where your Batch compute environment is located.",
                     "fa_icon": "fas fa-globe",
                     "help_text": "Specify your AWS region (e.g., 'us-east-1', 'us-west-2'). Required when using -profile awsbatch."
+                },
+                "cost_project": {
+                    "type": "string",
+                    "default": "noveltree",
+                    "description": "Project label to apply to AWS Batch jobs for cost allocation.",
+                    "fa_icon": "fas fa-tags"
+                },
+                "cost_dataset": {
+                    "type": "string",
+                    "default": "unset",
+                    "description": "Dataset label to apply to AWS Batch jobs for cost allocation.",
+                    "fa_icon": "fas fa-tags"
+                },
+                "cost_owner": {
+                    "type": "string",
+                    "default": "unknown",
+                    "description": "Owner label to apply to AWS Batch jobs for cost allocation.",
+                    "fa_icon": "fas fa-tags"
+                },
+                "cost_run_id": {
+                    "type": "string",
+                    "description": "Run identifier label to apply to AWS Batch jobs for cost allocation. Defaults to NOVELTREE_RUN_ID if set, otherwise a timestamp.",
+                    "fa_icon": "fas fa-tags"
                 }
             }
         },


### PR DESCRIPTION
This branch adds AWS cost-allocation labels to the Arcadia production profile so NovelTree runs on AWS Batch can be tracked by project, dataset, owner, run ID, and pipeline.

Intent:

- Make AWS Batch jobs from `-profile arcadia` easier to attribute in AWS billing/cost analysis.
- Allow users to override dataset, owner, and run identifiers at launch time, e.g. for test runs or named production runs.
- Facilitate the prediction of runtime and costs for new runs based on dataset attributes

Changes:

- Adds default cost-label params in conf/arcadia.config:
    - `cost_project`
    - `cost_dataset`
    - `cost_owner`
    - `cost_run_id`

- Wires those params into `process.resourceLabels`, which Nextflow submits as AWS Batch job tags.
- Adds the new `--cost_*` params to `nextflow_schema.json` so they appear in help/docs and can be validated like other pipeline parameters.